### PR TITLE
Put types into devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "node": ">=16.3"
   },
   "dependencies": {
-    "@types/node": "^16.4.0",
-    "@types/ws": "^8.0.0",
     "chalk": "^4.1.1",
     "tweetnacl": "^1.0.3",
     "ws": "^8.0.0"
   },
   "devDependencies": {
+    "@types/node": "^16.4.0",
+    "@types/ws": "^8.0.0",
     "typescript": "^4.8.2"
   }
 }


### PR DESCRIPTION
It is unnecessary to install them in production.